### PR TITLE
Bs/add auto doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,9 @@
 
 All notable changes to hubdata are documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com), and the
-project uses [Semantic Versioning](https://semver.org/).
+## 0.1.dev*
+
+## Added
+
+- `HubConfig` class
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,5 @@
+:og:description: hubdata: Python tools for accessing and working with the hubverse
+
 .. hubdata documentation index file,
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -9,6 +11,7 @@
 
    usage
    CONTRIBUTING
+   reference/index
    CHANGELOG
 
 .. include:: readme.md

--- a/docs/source/reference/hubconfig.rst
+++ b/docs/source/reference/hubconfig.rst
@@ -1,0 +1,8 @@
+:og:description: hubdata: Python tools for accessing and working with the hubverse
+
+==========
+HubConfig
+==========
+
+.. autoclass:: hubdata.HubConfig
+    :members:

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,0 +1,7 @@
+API reference
+=================
+
+.. toctree::
+
+   hubconfig
+


### PR DESCRIPTION
This PR adds an initial documentation page for the new HubConfig class.

Previewing the auto-generated documentation surfaced a need to fix up the colors for autodoc content, which we can do in a follow-up change 🙈 