### PR TITLE
Tweak documentation styling

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -68,8 +68,6 @@ th.field-name {
 }
 
 tt, code {
-    color: #F8F8F2;
-    background: #015259;
     border-radius: 0.3em;
     padding: 0.0em 0.3em;
 }
@@ -86,10 +84,6 @@ a.reference.internal, a.reference.internal:hover {
     border-bottom: none;
 }
 
-a.reference.internal:hover code {
-    background: #027bab
-}
-
 a.reference.internal:hover code.xref span.pre {
     color: #F8F8F2;
     background: #027bab;
@@ -99,11 +93,6 @@ a.reference.internal:hover code.xref span.pre {
 tt.xref, code.xref, a tt {
     background: none;
     border-bottom: none;
-}
-
-code.literal {
-    color: #F8F8F2;
-    background: #015259;
 }
 
 pre {

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -50,6 +50,14 @@ div.sphinxsidebar a {
     color: #003d45;
 }
 
+div.viewcode-block:target {
+    background: none;
+}
+
+div.viewcode-block a:visited {
+    color: #5FCDE3
+}
+
 code.descname {
     color: #6840ab;
 }


### PR DESCRIPTION
This PR adjusts two styles for the Sphinx-based documentation included with hub-data:

- Removes the yellow background color for the source code view
- Removes the dark green background of words styled by `code`

The documentation can be previewed by fetching this branch and then running:

```
uv run --group docs sphinx-autobuild docs/source docs/_build/html
```

For convenience, here's what the "code view" looks like on the main branch:

<img width="1049" alt="Screenshot 2025-04-24 at 2 10 32 PM" src="https://github.com/user-attachments/assets/aed011c7-b940-46f4-8f9e-c3a927cd8939" />



And what it looks like on this feature branch:



<img width="1048" alt="Screenshot 2025-04-24 at 1 20 46 PM" src="https://github.com/user-attachments/assets/f3f5c308-26a3-47ba-91a7-54c6e9921314" />
