### PR TITLE
add support for cloud-based hubs

### DIFF
--- a/src/hubdata/app.py
+++ b/src/hubdata/app.py
@@ -22,6 +22,9 @@ def cli():
 def print_schema(hub_path):
     """
     A subcommand that prints the output of `create_hub_schema()` for `hub_path`.
+
+    :param hub_path: as passed to `connect_hub()`: either a local file system hub path or a cloud-based hub URI.
+        Note: A local file system path must be an ABSOLUTE path and not a relative one
     """
     try:
         hub_connection = connect_hub(hub_path)
@@ -48,7 +51,7 @@ def print_schema(hub_path):
             padding=(1, 2),
             subtitle='[italic]hubdata[/italic]',
             subtitle_align='right',
-            title=f'[bright_red]{hub_path.name}[/bright_red]',
+            title='[bright_red]schema[/bright_red]',
             title_align='left')
     )
 
@@ -60,7 +63,8 @@ def print_dataset_info(hub_path):
     A subcommand that prints dataset information for `hub_path`. Currently only works with a UnionDataset of
     FileSystemDatasets.
 
-    :param hub_path: as passed to `connect_hub()`: either a local file system hub path or a cloud-based hub URI
+    :param hub_path: as passed to `connect_hub()`: either a local file system hub path or a cloud-based hub URI.
+        Note: A local file system path must be an ABSOLUTE path and not a relative one
     """
     try:
         hub_connection = connect_hub(hub_path)
@@ -104,7 +108,7 @@ def print_dataset_info(hub_path):
             padding=(1, 2),
             subtitle='[italic]hubdata[/italic]',
             subtitle_align='right',
-            title=f'[bright_red]{hub_path}[/bright_red]',
+            title='[bright_red]dataset[/bright_red]',
             title_align='left')
     )
 

--- a/src/hubdata/app.py
+++ b/src/hubdata/app.py
@@ -1,4 +1,3 @@
-import pathlib
 
 import click
 import pyarrow as pa
@@ -19,12 +18,16 @@ def cli():
 
 
 @cli.command(name='schema')
-@click.argument('hub_path', type=click.Path(file_okay=False, exists=True, path_type=pathlib.Path))
+@click.argument('hub_path')
 def print_schema(hub_path):
     """
     A subcommand that prints the output of `create_hub_schema()` for `hub_path`.
     """
-    hub_connection = connect_hub(hub_path)
+    try:
+        hub_connection = connect_hub(hub_path)
+    except Exception as ex:
+        print(f'error connecting to hub: {ex}')
+        return
 
     # create the hub_path group lines
     hub_path_lines = ['[b]hub_path[/b]:',
@@ -51,16 +54,23 @@ def print_schema(hub_path):
 
 
 @cli.command(name='dataset')
-@click.argument('hub_path', type=click.Path(file_okay=False, exists=True, path_type=pathlib.Path))
+@click.argument('hub_path')
 def print_dataset_info(hub_path):
     """
     A subcommand that prints dataset information for `hub_path`. Currently only works with a UnionDataset of
     FileSystemDatasets.
+
+    :param hub_path: as passed to `connect_hub()`: either a local file system hub path or a cloud-based hub URI
     """
-    hub_connection = connect_hub(hub_path)
+    try:
+        hub_connection = connect_hub(hub_path)
+    except Exception as ex:
+        print(f'error connecting to hub: {ex}')
+        return
+
     hub_ds = hub_connection.get_dataset()
-    if not isinstance(hub_ds, pa.dataset.UnionDataset):
-        print(f'sorry, currently only supports pa.dataset.UnionDataset, not {type(hub_ds)}')
+    if not isinstance(hub_ds, pa.dataset.FileSystemDataset) and not isinstance(hub_ds, pa.dataset.UnionDataset):
+        print(f'unsupported dataset type: {type(hub_ds)}')
         return
 
     # create the hub_path group lines
@@ -73,12 +83,15 @@ def print_dataset_info(hub_path):
         schema_lines.append(f'- [green]{field.name}[/green]: [bright_magenta]{field.type}[/bright_magenta]')
 
     # create the dataset group lines
-    num_files = sum([len(child_ds.files) for child_ds in hub_ds.children])
-    file_types = ', '.join([child_ds.format.default_extname for child_ds in hub_ds.children])
+    filesystem_datasets = hub_ds.children if isinstance(hub_ds, pa.dataset.UnionDataset) else [hub_ds]
+    num_files = sum([len(child_ds.files) for child_ds in filesystem_datasets])
+    found_file_types = ', '.join([child_ds.format.default_extname for child_ds in filesystem_datasets])
+    admin_file_types = ', '.join(hub_connection.admin['file_format'])
     num_rows = hub_ds.count_rows()
     dataset_lines = ['\n[b]dataset[/b]:',
                      f'- [green]files[/green]: [bright_magenta]{num_files:,}[/bright_magenta]',
-                     f'- [green]types[/green]: [bright_magenta]{file_types}[/bright_magenta]',
+                     f'- [green]types[/green]: [bright_magenta]{found_file_types} (found) | {admin_file_types} (admin)'
+                     f'[/bright_magenta]',
                      f'- [green]rows[/green]: [bright_magenta]{num_rows:,}[/bright_magenta]']
 
     # finally, print a Panel containing all the groups
@@ -91,7 +104,7 @@ def print_dataset_info(hub_path):
             padding=(1, 2),
             subtitle='[italic]hubdata[/italic]',
             subtitle_align='right',
-            title=f'[bright_red]{hub_path.name}[/bright_red]',
+            title=f'[bright_red]{hub_path}[/bright_red]',
             title_align='left')
     )
 

--- a/src/hubdata/connect_hub.py
+++ b/src/hubdata/connect_hub.py
@@ -24,7 +24,8 @@ def connect_hub(hub_path: str | Path):
         a hub's root directory. it is passed to https://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html#pyarrow.fs.FileSystem.from_uri
         From that page:
             Recognized URI schemes are “file”, “mock”, “s3fs”, “gs”, “gcs”, “hdfs” and “viewfs”. In addition, the
-            argument can be a pathlib.Path object, or a string describing an absolute local path.
+            argument can be a local path, either a pathlib.Path object or a str. NB: Passing a local path as a str
+            requires an ABSOLUTE path, but passing the hub as a Path can be a relative path.
     :return: a HubConnection
     :raise: RuntimeError if `hub_path` is invalid
     """

--- a/src/hubdata/connect_hub.py
+++ b/src/hubdata/connect_hub.py
@@ -4,72 +4,76 @@ from pathlib import Path
 import pyarrow as pa
 import pyarrow.dataset as ds
 import structlog
+from pyarrow import fs
 
 from hubdata.create_hub_schema import create_hub_schema
 
 logger = structlog.get_logger()
 
 
-def connect_hub(hub_path: Path):
+def connect_hub(hub_path: str | Path):
     """
-    The main entry point for connecting to a hub. This will connect to data in a model output directory through a
-    Modeling Hub or directly. Data can be stored in a local directory or in the cloud on AWS or GCS. Calls
-    `create_hub_schema()` to get the schema to use when calling `HubConnection.get_dataset()`.
+    The main entry point for connecting to a hub, providing access to the instance variables documented in
+    `HubConnection`, including admin.json and tasks.json as dicts. It also allows connecting to data in the hub's model
+    output directory for querying and filtering across all model files. The hub can be located in a local file system or
+    in the cloud on AWS or GCS. Note: Calls `create_hub_schema()` to get the schema to use when calling
+    `HubConnection.get_dataset()`. See: https://docs.hubverse.io/en/latest/user-guide/hub-structure.html for details on
+    how hubs directories are laid out.
 
-    :param hub_path: Path to a hub's root directory. see: https://docs.hubverse.io/en/latest/user-guide/hub-structure.html
+    :param hub_path: str (for local file system hubs or cloud based ones) or Path (local file systems only) pointing to
+        a hub's root directory. it is passed to https://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html#pyarrow.fs.FileSystem.from_uri
+        From that page:
+            Recognized URI schemes are “file”, “mock”, “s3fs”, “gs”, “gcs”, “hdfs” and “viewfs”. In addition, the
+            argument can be a pathlib.Path object, or a string describing an absolute local path.
     :return: a HubConnection
-    :raise: RuntimeError if `hub_path` is not found
+    :raise: RuntimeError if `hub_path` is invalid
     """
     return HubConnection(hub_path)
 
 
 class HubConnection:
     """
-    Provides convenient access to various parts of a hub's `tasks.json` file. Use the `connect_hub` factory function to
-    create instances of this class, rather than by direct instantiation.
+    Provides convenient access to various parts of a hub's `tasks.json` file. Use the `connect_hub` function to create
+    instances of this class, rather than by direct instantiation
 
     Instance variables:
-    - hub_path: Path to a hub's root directory. see: https://docs.hubverse.io/en/latest/user-guide/hub-structure.html
-    - schema: the pa.Schema for `HubConnection.get_dataset()`. created via `create_hub_schema()`
+    - hub_path: str pointing to a hub's root directory as passed to `connect_hub()`
+    - schema: the pa.Schema for `HubConnection.get_dataset()`. created by the constructor via `create_hub_schema()`
     - admin: the hub's `admin.json` contents as a dict
     - tasks: "" `tasks.json` ""
     - model_output_dir: Path to the hub's model output directory
     """
 
 
-    def __init__(self, hub_path: Path):
+    def __init__(self, hub_path: str | Path):
         """
-        :param hub_path: Path to a hub's root directory. see: https://docs.hubverse.io/en/latest/user-guide/hub-structure.html
+        :param hub_path: str or Path pointing to a hub's root directory as passed to `connect_hub()`
         """
+        # set self.hub_path and then get an arrow FileSystem for it, letting it decide the correct subclass based on
+        # that arg, catching any errors. also set two internal instance variables used by HubConnection.get_dataset():
+        # self._filesystem and self._filesystem_path
+        self.hub_path: str | Path = hub_path
+        try:
+            self._filesystem, self._filesystem_path = fs.FileSystem.from_uri(self.hub_path)
+        except Exception:
+            raise RuntimeError(f'invalid hub_path: {self.hub_path}')
 
-        # set hub_path, first checking for existence
-        self.hub_path = hub_path
-        if not self.hub_path.exists():
-            raise RuntimeError(f'hub_path not found: {self.hub_path}')
-
-        # set self.admin, first checking for admin.json existence
-        admin_json_file = self.hub_path / 'hub-config' / 'admin.json'
-        if not admin_json_file.exists():
-            raise RuntimeError(f'admin.json not found: {admin_json_file}')
-
-        with open(admin_json_file) as fp:
-            self.admin: dict = json.load(fp)
-
-        # set self.tasks, first checking for tasks.json existence
-        tasks_json_file = self.hub_path / 'hub-config' / 'tasks.json'
-        if not tasks_json_file.exists():
-            raise RuntimeError(f'tasks.json not found: {tasks_json_file}')
-
-        with open(tasks_json_file) as fp:
-            self.tasks: dict = json.load(fp)
+        # set self.admin and self.tasks, checking for existence
+        try:
+            with self._filesystem.open_input_file(f'{self._filesystem_path}/hub-config/admin.json') as admin_fp, \
+                    self._filesystem.open_input_file(f'{self._filesystem_path}/hub-config/tasks.json') as tasks_fp:
+                self.admin = json.load(admin_fp)
+                self.tasks = json.load(tasks_fp)
+        except Exception as ex:
+            raise RuntimeError(f'admin.json or tasks.json not found: {ex}')
 
         # set schema
         self.schema = create_hub_schema(self.tasks)
 
         # set self.model_output_dir, first checking for directory existence
         model_output_dir_name = self.admin['model_output_dir'] if 'model_output_dir' in self.admin else 'model-output'
-        model_output_dir = Path(hub_path / model_output_dir_name)
-        if not model_output_dir.exists():
+        model_output_dir = f'{self._filesystem_path}/{model_output_dir_name}'
+        if self._filesystem.get_file_info(model_output_dir).type == fs.FileType.NotFound:
             logger.warn(f'model_output_dir not found: {model_output_dir!r}')
         self.model_output_dir = model_output_dir
 
@@ -78,22 +82,24 @@ class HubConnection:
         """
         :return: a pyarrow.dataset.Dataset for my model_output_dir
         """
-        return self._get_path_dataset()
-
-
-    def _get_path_dataset(self) -> ds:
-        """
-        :return: a pyarrow.dataset.UnionDataset with one child pyarrow.dataset.FileSystemDataset for each file_format in
-        self.admin.
-        """
         # create the dataset. NB: we are using dataset "directory partitioning" to automatically get the `model_id`
-        # column from directory names. NB: each dataset is a pyarrow._dataset.FileSystemDataset (so far!)
-        datasets = [ds.dataset(self.model_output_dir, format=file_format,
+        # column from directory names
+
+        # NB: we force file_formats to .parquet if not a LocalFileSystem (e.g., an S3FileSystem). otherwise we use the
+        # list from self.admin['file_format']
+        file_formats = ['parquet'] if not isinstance(self._filesystem, fs.LocalFileSystem) \
+            else self.admin['file_format']
+        schema = create_hub_schema(self.tasks)
+        datasets = [ds.dataset(self.model_output_dir, filesystem=self._filesystem, format=file_format,
                                partitioning=['model_id'],  # NB: hard-coded partitioning!
-                               exclude_invalid_files=True, schema=self.schema)
-                    for file_format in self.admin['file_format']]
-        return ds.dataset([dataset for dataset in datasets
-                           if isinstance(dataset, pa.dataset.FileSystemDataset) and (len(dataset.files) != 0)])
+                               exclude_invalid_files=True, schema=schema)
+                    for file_format in file_formats]
+        datasets = [dataset for dataset in datasets if len(dataset.files) != 0]
+        if len(datasets) == 1:
+            return datasets[0]
+        else:
+            return ds.dataset([dataset for dataset in datasets
+                               if isinstance(dataset, pa.dataset.FileSystemDataset) and (len(dataset.files) != 0)])
 
 
     def to_table(self, *args, **kwargs) -> pa.Table:


### PR DESCRIPTION
This PR changes connect_hub.py to use pyarrow's [filesystem interface](https://arrow.apache.org/docs/python/filesystems.html) instead of direct Path calls. That interface abstracts out local and cloud-based file access.

Notes:
- the `connect_hub()` argument is now an absolute str instead of Path (for local filesystem hubs), which required casting in tests
- we don't directly check for `hub_path` existence because it might not be in local file system. instead we pick up a problem when we try to open either admin.json or tasks.json
- `HubConnection.get_dataset()`: we force file_formats to .parquet if not a LocalFileSystem (e.g., an S3FileSystem). otherwise we use the list from `self.admin['file_format']`
