### PR TITLE
fixed sphinx-build errors that were exposed by the `--fail-on-warning` option in publish-docs.yaml . updated dev docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,11 @@ Please ensure the following are true before creating the PR:
 
 - Your change is covered by tests, if applicable
 - Project documentation is updated, if applicable
-- The following local dev commands pass (see [dev.md](docs/source/dev.md)):
+- The following local dev commands pass without warnings or errors (see **docs/source/dev.md**):
     - `uv run pytest`
     - `uv run ruff check`
     - `uv tool run mypy . --ignore-missing-imports --disable-error-code=attr-defined`
+    - `uv run --group docs sphinx-build docs/source docs/_build/html --fresh-env --fail-on-warning`
 - The `## unreleased` section of [CHANGELOG.md](CHANGELOG.md) contains a description of your change
 
 The PR itself should:

--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -52,7 +52,7 @@ rm -rf htmlcov/index.html
 Run the following command to build documentation:
 
 ```bash
-uv run --group docs sphinx-build docs/source docs/_build/html
+uv run --group docs sphinx-build docs/source docs/_build/html --fresh-env --fail-on-warning
 ```
 
 To do the same and then serve documentation locally for debugging:

--- a/src/hubdata/connect_hub.py
+++ b/src/hubdata/connect_hub.py
@@ -22,10 +22,9 @@ def connect_hub(hub_path: str | Path):
 
     :param hub_path: str (for local file system hubs or cloud based ones) or Path (local file systems only) pointing to
         a hub's root directory. it is passed to https://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html#pyarrow.fs.FileSystem.from_uri
-        From that page:
-            Recognized URI schemes are “file”, “mock”, “s3fs”, “gs”, “gcs”, “hdfs” and “viewfs”. In addition, the
-            argument can be a local path, either a pathlib.Path object or a str. NB: Passing a local path as a str
-            requires an ABSOLUTE path, but passing the hub as a Path can be a relative path.
+        From that page: Recognized URI schemes are “file”, “mock”, “s3fs”, “gs”, “gcs”, “hdfs” and “viewfs”. In
+        addition, the argument can be a local path, either a pathlib.Path object or a str. NB: Passing a local path as a
+        str requires an ABSOLUTE path, but passing the hub as a Path can be a relative path.
     :return: a HubConnection
     :raise: RuntimeError if `hub_path` is invalid
     """


### PR DESCRIPTION
The fixed warnings (were treated as errors):
- docstring of hubdata.connect_hub.connect_hub:11:Unexpected indentation.
- 'myst' cross-reference target not found: 'docs/source/dev.md' [myst.xref_missing]