### PR TITLE
speeds up cloud-based datasets

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -74,9 +74,9 @@ print(pa_table.shape)
 # (1350, 2)
 ```
 
-## HubConnection.to_table() helper function
+## HubConnection.to_table() convenience function
 
-If you just want the pyarrow Table and don't need the pyarrow `Dataset` returned by `HubConnection.get_dataset()` then you can use the `HubConnection.to_table()` helper function, which calls `HubConnection.get_dataset()` for you and then passes its args through to the returned `Dataset.to_table()`. So the above example in full would be:
+If you just want the pyarrow Table and don't need the pyarrow `Dataset` returned by `HubConnection.get_dataset()` then you can use the `HubConnection.to_table()` convenience function, which calls `HubConnection.get_dataset()` for you and then passes its args through to the returned `Dataset.to_table()`. So the above example in full would be:
 
 ```python
 from pathlib import Path

--- a/src/hubdata/app.py
+++ b/src/hubdata/app.py
@@ -26,8 +26,10 @@ def print_schema(hub_path):
     :param hub_path: as passed to `connect_hub()`: either a local file system hub path or a cloud-based hub URI.
         Note: A local file system path must be an ABSOLUTE path and not a relative one
     """
+    console = Console()
     try:
-        hub_connection = connect_hub(hub_path)
+        with console.status('Connecting to hub...'):
+            hub_connection = connect_hub(hub_path)
     except Exception as ex:
         print(f'error connecting to hub: {ex}')
         return
@@ -42,7 +44,6 @@ def print_schema(hub_path):
         schema_lines.append(f'- [green]{field.name}[/green]: [bright_magenta]{field.type}[/bright_magenta]')
 
     # finally, print a Panel containing all the groups
-    console = Console()
     console.print(
         Panel(
             Group(Group(*hub_path_lines), Group(*schema_lines)),
@@ -65,13 +66,16 @@ def print_dataset_info(hub_path):
     :param hub_path: as passed to `connect_hub()`: either a local file system hub path or a cloud-based hub URI.
         Note: A local file system path must be an ABSOLUTE path and not a relative one
     """
+    console = Console()
     try:
-        hub_connection = connect_hub(hub_path)
+        with console.status('Connecting to hub...'):
+            hub_connection = connect_hub(hub_path)
     except Exception as ex:
         print(f'error connecting to hub: {ex}')
         return
 
-    hub_ds = hub_connection.get_dataset()
+    with console.status('Getting dataset...'):
+        hub_ds = hub_connection.get_dataset()
     if not isinstance(hub_ds, pa.dataset.FileSystemDataset) and not isinstance(hub_ds, pa.dataset.UnionDataset):
         print(f'unsupported dataset type: {type(hub_ds)}')
         return
@@ -90,7 +94,8 @@ def print_dataset_info(hub_path):
     num_files = sum([len(child_ds.files) for child_ds in filesystem_datasets])
     found_file_types = ', '.join([child_ds.format.default_extname for child_ds in filesystem_datasets])
     admin_file_types = ', '.join(hub_connection.admin['file_format'])
-    num_rows = hub_ds.count_rows()
+    with console.status('Counting rows...'):
+        num_rows = hub_ds.count_rows()
     dataset_lines = ['\n[b]dataset[/b]:',
                      f'- [green]files[/green]: [bright_magenta]{num_files:,}[/bright_magenta]',
                      f'- [green]types[/green]: [bright_magenta]{found_file_types} (found) | {admin_file_types} (admin)'
@@ -98,7 +103,6 @@ def print_dataset_info(hub_path):
                      f'- [green]rows[/green]: [bright_magenta]{num_rows:,}[/bright_magenta]']
 
     # finally, print a Panel containing all the groups
-    console = Console()
     console.print(
         Panel(
             Group(Group(*hub_path_lines), Group(*schema_lines), Group(*dataset_lines)),

--- a/src/hubdata/connect_hub.py
+++ b/src/hubdata/connect_hub.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Iterable
 
 import pyarrow as pa
 import pyarrow.dataset as ds
@@ -78,23 +79,41 @@ class HubConnection:
         self.model_output_dir = model_output_dir
 
 
-    def get_dataset(self) -> ds:
+    def get_dataset(self, ignore_files: Iterable[str] = ('README', '.DS_Store')) -> ds:
         """
+        Main entry point for getting a pyarrow dataset to work with. Prints a warning about any files that were skipped
+        during dataset file discovery.
+
+        :param: ignore_files a str list of file **names** (not paths) or file **prefixes** to ignore when discovering
+            model output files to include in dataset connections. Parent directory names should not be included. The
+            default is to ignore the common files `"README"` and `".DS_Store"`, but additional files can be excluded by
+            specifying them here.
         :return: a pyarrow.dataset.Dataset for my model_output_dir
         """
         # create the dataset. NB: we are using dataset "directory partitioning" to automatically get the `model_id`
-        # column from directory names
+        # column from directory names. regarding performance on S3-based datasets, we set `exclude_invalid_files=False`,
+        # which speeds up pyarrow's dataset processing, but opens the door to errors: "unsupported files may be present
+        # in the Dataset (resulting in an error at scan time)". we prevent this from happening by manually constructing
+        # and passing `ignore_prefixes` based on file extensions. this method accepts `ignore_files` to allow custom
+        # prefixes to ignore. it defaults to common ones for hubs
 
         # NB: we force file_formats to .parquet if not a LocalFileSystem (e.g., an S3FileSystem). otherwise we use the
         # list from self.admin['file_format']
         file_formats = ['parquet'] if not isinstance(self._filesystem, fs.LocalFileSystem) \
             else self.admin['file_format']
-        schema = create_hub_schema(self.tasks)
-        datasets = [ds.dataset(self.model_output_dir, filesystem=self._filesystem, format=file_format,
-                               partitioning=['model_id'],  # NB: hard-coded partitioning!
-                               exclude_invalid_files=True, schema=schema)
-                    for file_format in file_formats]
+        model_out_files = self._list_model_out_files()  # model_output_dir, type='file'
+        datasets = []
+        file_format_to_ignore_files: dict[str, list[fs.FileInfo]] = {}  # for warning
+        for file_format in file_formats:
+            _ignore_files = self._list_invalid_format_files(model_out_files, file_format, ignore_files)
+            file_format_to_ignore_files[file_format] = _ignore_files
+            dataset = ds.dataset(self.model_output_dir, filesystem=self._filesystem, format=file_format,
+                                 schema=self.schema, partitioning=['model_id'],  # NB: hard-coded partitioning!
+                                 exclude_invalid_files=False,
+                                 ignore_prefixes=[file_info.base_name for file_info in _ignore_files])
+            datasets.append(dataset)
         datasets = [dataset for dataset in datasets if len(dataset.files) != 0]
+        self._warn_unopened_files(model_out_files, ignore_files, file_format_to_ignore_files)
         if len(datasets) == 1:
             return datasets[0]
         else:
@@ -102,9 +121,57 @@ class HubConnection:
                                if isinstance(dataset, pa.dataset.FileSystemDataset) and (len(dataset.files) != 0)])
 
 
+    def _list_model_out_files(self) -> list[fs.FileInfo]:
+        """
+        get_dataset() helper that returns a list of all files in self.model_output_dir. note that for now uses
+        FileSystem.get_file_info() regardless of whether it's a LocalFileSystem or S3FileSystem. also note that no
+        filtering of files is done, i.e., invalid files might be included
+        """
+        return [file_info
+                for file_info in
+                self._filesystem.get_file_info(fs.FileSelector(self.model_output_dir, recursive=True))
+                if file_info.type == fs.FileType.File]
+
+
+    @staticmethod
+    def _list_invalid_format_files(model_out_files: list[fs.FileInfo], file_format: str,
+                                   ignore_files_default: Iterable[str]) -> list[fs.FileInfo]:
+        """
+        get_dataset() helper that returns a list of file paths in `model_out_files` that do *not* match the
+        `file_format` extension
+        """
+        return [file_info for file_info in model_out_files
+                if (file_info.extension != file_format)
+                or any([file_info.base_name.startswith(ignore_file) for ignore_file in ignore_files_default])]
+
+
+    @staticmethod
+    def _warn_unopened_files(model_out_files: list[fs.FileInfo], ignore_files_default: Iterable[str],
+                             file_format_to_ignore_files: dict[str, list[fs.FileInfo]]):
+        """
+        get_dataset() helper
+        """
+
+
+        def is_present_all_file_formats(file_info):
+            return all([file_info in ignore_files for ignore_files in file_format_to_ignore_files.values()])
+
+
+        # warn about files in model_out_files that are present in all file_format_to_ignore_files.values(), i.e., that
+        # were never OK for any file_format
+        unopened_files = [model_out_file for model_out_file in model_out_files
+                          if is_present_all_file_formats(model_out_file)
+                          and not any([model_out_file.base_name.startswith(ignore_file)
+                                       for ignore_file in ignore_files_default])]
+
+        if unopened_files:
+            logger.warn(f'ignored {len(unopened_files)} file{'s' if len(unopened_files) > 1 else ''}: '
+                        f'{[model_out_file.path for model_out_file in unopened_files]}')
+
+
     def to_table(self, *args, **kwargs) -> pa.Table:
         """
-        A helper function that simply passes args and kwargs to `pyarrow.dataset.Dataset.to_table()`, returning the
+        A convenience function that simply passes args and kwargs to `pyarrow.dataset.Dataset.to_table()`, returning the
         `pyarrow.Table`.
         """
         return self.get_dataset().to_table(*args, **kwargs)

--- a/test/hubs/v4_flusight/forecasts/README.md
+++ b/test/hubs/v4_flusight/forecasts/README.md
@@ -1,0 +1,1 @@
+This is a non-model output file for testing. Because the file name begins with 'README', it will be ignored by default and no warning will be given.

--- a/test/hubs/v4_flusight/forecasts/invalid.txt
+++ b/test/hubs/v4_flusight/forecasts/invalid.txt
@@ -1,0 +1,1 @@
+This is a non-model output file for testing. Because the file name does not begin with 'README', '.DS_Store', it will not be ignored by default and a warning will be given.


### PR DESCRIPTION
Speedup is similar to the approach taken by the R code: `HubConnection.get_dataset()` passes `exclude_invalid_files=False` to `ds.dataset()`, along with `ignore_prefixes` to prevent scan errors.

The result is ~2x faster, but still fairly slow for S3-based hubs - mainly connecting (~5s on my machine) and counting rows (varies).

Notes:
- warns about ignored files
- adds two ignored files for tests
- adds test for listing model files and invalid files
- adds app status updates (useful when running against S3-based hubs)