### PR TITLE
bump version '0.1.2' -> '0.1.3'

### DIFF
--- a/src/hubdata/__init__.py
+++ b/src/hubdata/__init__.py
@@ -3,4 +3,4 @@ from hubdata.create_hub_schema import create_hub_schema
 
 __all__ = ['connect_hub', 'HubConnection', 'create_hub_schema']
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'


### PR DESCRIPTION
I missed this in the last commit.