### PR TITLE
Add Plausible analytics to docs site

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,11 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+{{ super() }}
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-_SeES0qkE5KfksH84IX9u.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>
+{% endblock %}


### PR DESCRIPTION
Adds privacy-friendly Plausible analytics to the Sphinx docs site by injecting the shared `hubverse-org.github.io` snippet into `<head>` via a `_templates/layout.html` override of the `extrahead` block.

Part of consolidating all hubverse `hubverse-org.github.io` sites under a single Plausible site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)